### PR TITLE
Added NX option when setting new redis lock

### DIFF
--- a/redis_lock.go
+++ b/redis_lock.go
@@ -13,11 +13,16 @@ var ErrLockMismatch = errors.New("key is locked with a different secret")
 // lockScript is the locking script
 const lockScript = `
 local v = redis.call("GET", KEYS[1])
-if v == false or v == ARGV[1]
+if v == false
 then
-	return redis.call("SET", KEYS[1], ARGV[1], "EX", ARGV[2]) and 1
+	return redis.call("SET", KEYS[1], ARGV[1], "NX", "EX", ARGV[2]) and 1
 else
-	return 0
+	if v == ARGV[1]
+	then
+		return redis.call("SET", KEYS[1], ARGV[1], "EX", ARGV[2]) and 1
+	else
+		return 0
+	end
 end
 `
 

--- a/scripts_test.go
+++ b/scripts_test.go
@@ -155,7 +155,7 @@ func TestRegisterScript(t *testing.T) {
 		// Another script
 		sha, err = RegisterScript(context.Background(), client, lockScript)
 		assert.NoError(t, err)
-		assert.Equal(t, "e60d96cbb3894dc682fafae2980ad674822f99e1", sha)
+		assert.Equal(t, "7168a6204ea41fc8e23d1c42b1ebdf1ec5abff4f", sha)
 
 		// Another script
 		sha, err = RegisterScript(context.Background(), client, releaseLockScript)


### PR DESCRIPTION
This prevents the (unlikely) chance that a lock is created at the same time